### PR TITLE
fix: check if OPENAI_BASE_URL being set

### DIFF
--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -2,11 +2,16 @@ from . import backend_anthropic, backend_openai, backend_openrouter
 from .utils import FunctionSpec, OutputType, PromptType, compile_prompt_to_md
 import re
 import logging
+import os
 
 logger = logging.getLogger("aide")
 
 
 def determine_provider(model: str) -> str:
+    # If OPENAI_BASE_URL is set, assume we're using a local LLM setup with OpenAI-compatible API
+    if os.getenv("OPENAI_BASE_URL"):
+        return "openai"
+
     if model.startswith("gpt-") or re.match(r"^o\d", model):
         return "openai"
     elif model.startswith("claude-"):


### PR DESCRIPTION
## Description

* add check for env `OPENAI_BASE_URL`

## Screenshots/videos:

example run

```
data_dir: !!python/object/apply:pathlib.PosixPath
- /
- Users
- dex
- Work
- wecoai
- aideml
- aide
- example_tasks
- house_prices
desc_file: null
goal: Predict the sales price for each house
eval: Use the RMSE metric between the logarithm of the predicted and observed values.
log_dir: !!python/object/apply:pathlib.PosixPath
- /
- Users
- dex
- Work
- wecoai
- aideml
- logs
- 2-onyx-sambar-of-radiance
workspace_dir: !!python/object/apply:pathlib.PosixPath
- /
- Users
- dex
- Work
- wecoai
- aideml
- workspaces
- 2-onyx-sambar-of-radiance
preprocess_data: true
copy_data: true
exp_name: 2-onyx-sambar-of-radiance
exec:
  timeout: 3600
  agent_file_name: runfile.py
  format_tb_ipython: false
generate_report: true
report:
  model: qwen2.5
  temp: 1.0
agent:
  steps: 20
  k_fold_validation: 5
  expose_prediction: false
  data_preview: true
  code:
    model: qwen2.5
    temp: 0.5
  feedback:
    model: qwen2.5
    temp: 0.5
  search:
    max_debug_depth: 3
    debug_prob: 0.5
    num_drafts: 5
```
