### PR TITLE
Resolve moderate package vulnerability CVE-2024-47081

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ openai>=1.69.0
 anthropic>=0.20.0
 pandas==2.1.4
 pytest==7.4.3
-requests==2.32.2
+requests>=2.32.4
 scikit-learn==1.5.0
 rich==13.7.0
 scipy==1.11.4


### PR DESCRIPTION
Changed requests version requirement from 2.32.2 to >=2.32.4 to fix CVE-2024-47081

## Description

* requirements.txt - replaced the exact pin ==2.32.2 with a floor constraint >=2.32.4
* We bump the requests library to a safe version so calls stay secure and worry-free
* No application logic touched - tests still pass
* Resolves the security alert for CVE-2024-47081

## Screenshots/videos:
_Not applicable – dependency upgrade only._
