### PR TITLE
fix(backend): correct regex for openai model routing

### DIFF
--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("aide")
 
 def determine_provider(model: str) -> str:
     # Check if model matches OpenAI patterns first
-    if re.match(r"^(gpt-.*|o\d+.*|o\d|codex-mini-latest)$", model):
+    if re.match(r"^(gpt-.*|o\d+.*|codex-mini-latest)$", model):
         return "openai"
     elif model.startswith("claude-"):
         return "anthropic"

--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("aide")
 
 def determine_provider(model: str) -> str:
     # Check if model matches OpenAI patterns first
-    if re.match(r"^(gpt-.*|o\d+.*|codex-mini-latest)$", model):
+    if re.match(r"^(gpt-.*|o\d+(-.*)?|codex-mini-latest)$", model):
         return "openai"
     elif model.startswith("claude-"):
         return "anthropic"

--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("aide")
 
 def determine_provider(model: str) -> str:
     # Check if model matches OpenAI patterns first
-    if re.match(r"^(gpt-|o\d-|codex-mini-latest$)", model):
+    if re.match(r"^(gpt-.*|o\d-.*|o\d|codex-mini-latest)$", model):
         return "openai"
     elif model.startswith("claude-"):
         return "anthropic"

--- a/aide/backend/__init__.py
+++ b/aide/backend/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("aide")
 
 def determine_provider(model: str) -> str:
     # Check if model matches OpenAI patterns first
-    if re.match(r"^(gpt-.*|o\d-.*|o\d|codex-mini-latest)$", model):
+    if re.match(r"^(gpt-.*|o\d+.*|o\d|codex-mini-latest)$", model):
         return "openai"
     elif model.startswith("claude-"):
         return "anthropic"


### PR DESCRIPTION
## Description

The previous regex was too restrictive and did not correctly route model aliases like 'o3' or 'o3-2025-04-16' to the OpenAI backend. This change updates the regex to correctly handle these cases.


