### PR TITLE
fix(interpreter): execute agent code with __name__ == "__main__" (#62)

### DIFF
--- a/aide/interpreter.py
+++ b/aide/interpreter.py
@@ -135,7 +135,16 @@ class Interpreter:
     ) -> None:
         self.child_proc_setup(result_outq)
 
-        global_scope: dict = {}
+        # `exec` with an empty globals dict leaves `__name__` to resolve through
+        # builtins, where it is "builtins" -- so the standard
+        # `if __name__ == "__main__":` guard is never true and the script's body
+        # silently never runs (clean exit, no output, no exception). Mirror the
+        # semantics of running the file directly. See #62.
+        global_scope: dict = {
+            "__name__": "__main__",
+            "__file__": self.agent_file_name,
+            "__builtins__": __builtins__,
+        }
         while True:
             code = code_inq.get()
             os.chdir(str(self.working_dir))

--- a/tests/test_interpreter_main_guard.py
+++ b/tests/test_interpreter_main_guard.py
@@ -1,0 +1,78 @@
+"""Regression tests for the interpreter's execution globals.
+
+Agent-generated code very often wraps its body in the standard
+`if __name__ == "__main__":` guard. If the interpreter execs that code with an
+empty globals dict, `__name__` resolves through builtins to "builtins", the
+guard is False, and the body never runs -- silently, with a clean exit code and
+no traceback. See issue #62.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aide.interpreter import Interpreter
+
+
+@pytest.fixture
+def interpreter():
+    workdir = Path(tempfile.mkdtemp())
+    (workdir / "working").mkdir(exist_ok=True)
+    interp = Interpreter(workdir, timeout=60)
+    yield interp
+    interp.cleanup_session()
+
+
+def test_dunder_name_is_main(interpreter):
+    """`__name__` must be "__main__", as it is when running `python runfile.py`."""
+    result = interpreter.run('print(f"name={__name__}")', True)
+    assert "name=__main__" in "".join(result.term_out)
+
+
+def test_main_guard_body_runs(interpreter):
+    """The `if __name__ == "__main__":` guard must fire, so main() executes.
+
+    Without it the script exits 0 with no output and no exception -- the agent
+    sees a "successful" run that printed no metric.
+    """
+    code = "\n".join(
+        [
+            "def main():",
+            '    print("CV RMSLE: 0.280261")',
+            "",
+            'if __name__ == "__main__":',
+            "    main()",
+        ]
+    )
+    result = interpreter.run(code, True)
+    assert result.exc_type is None
+    assert "CV RMSLE: 0.280261" in "".join(result.term_out)
+
+
+def test_builtins_available(interpreter):
+    """Builtins must resolve inside the exec'd script."""
+    result = interpreter.run("print(len([1, 2, 3]), max(4, 5))", True)
+    assert "3 5" in "".join(result.term_out)
+
+
+def test_plain_module_level_code_still_works(interpreter):
+    """Scripts without a guard must be unaffected by the fix."""
+    result = interpreter.run('print("no guard here")', True)
+    assert "no guard here" in "".join(result.term_out)
+
+
+def test_exception_still_reported(interpreter):
+    """Errors inside a guarded main() must still surface as exceptions."""
+    code = "\n".join(
+        [
+            "def main():",
+            '    raise ValueError("boom")',
+            "",
+            'if __name__ == "__main__":',
+            "    main()",
+        ]
+    )
+    result = interpreter.run(code, True)
+    assert result.exc_type == "ValueError"
+    assert "boom" in "".join(result.term_out)


### PR DESCRIPTION
## Description

**Fixes the silent no-op described in #62.**

Agent-generated scripts frequently wrap their body in the standard
`if __name__ == "__main__": main()` guard. `Interpreter._run_session` execs that code with
an empty globals dict:

```python
global_scope: dict = {}
exec(compile(code, self.agent_file_name, "exec"), global_scope)
```

With no `__name__` key in globals, Python resolves it through builtins, where
`__name__ == "builtins"`. The guard is therefore **False** and `main()` never runs.

@dexhunter already identified this fix in #62. This PR just lands it upstream, with tests
— and with evidence that the impact is larger than "no output", which I think is why it
was closed as a question rather than a bug.

### Why this is worth fixing rather than working around

The failure is **silent and it corrupts the search**. Verified against the real
`Interpreter`:

| run via | result |
|---|---|
| `Interpreter.run(...)` | `exc_type=None`, `exec_time=0.31s`, `term_out=[]` — **main() never ran** |
| `python runfile.py` | `CV RMSLE: 0.280261` |

Nothing reports an error, so the cascade continues:

1. Script exits cleanly with empty stdout. `exc_type is None`, so `parse_exec_result` sees no error.
2. The feedback model is asked to review empty output. In my runs `gpt-5-mini` returned
   **`metric: 0.0, is_bug: false`** while its own summary admitted *"The printed CV RMSLE
   value was not captured."*
3. `isinstance(0.0, float)` is True, so the metric stands and `is_buggy` stays False.
4. For any **lower-is-better** metric, `0.0` beats every honest score, so
   `Journal.get_best_node()` returns the empty-output node.
5. `search_policy()` is greedy, so it then improves *from* that node, and
   `Experiment.run` reports it as the best solution.

Observed collapse on a bike-sharing task (RMSLE, lower-is-better) — once a `0.0` node
became best, the search never escaped:

```
step 0: metric=0.280261   <- real, honest score
step 1: metric=0.0        <- __main__ guard; empty output; poisoned
step 3: metric=0.307197
step 4: metric=0.820558
step 6: metric=0.0
step 7: metric=0.0
step 8: metric=0.0
step 9: metric=0.0        <- degenerate attractor
```

After this fix, the same task with identical settings went from **RMSLE 0.833 → 0.265**,
and the bogus `0.0` metrics disappeared across all 5 tasks I benchmarked.

I hit this on 3 of 5 tabular tasks with `gpt-5.1-codex-mini` as the coding model. Since
the guard is idiomatic Python and LLMs emit it constantly, I suspect this quietly affects
a lot of runs — the symptom looks like "the model wrote a script that doesn't print its
metric", not like an interpreter bug.

## Summary of changes

* `aide/interpreter.py` — set the execution globals to mirror running the file directly:
  ```python
  global_scope: dict = {
      "__name__": "__main__",
      "__file__": self.agent_file_name,
      "__builtins__": __builtins__,
  }
  ```
  (`__name__` + `__builtins__` are @dexhunter's suggestion from #62; `__file__` is included
  because a real script has it and some code reads it.)
* `tests/test_interpreter_main_guard.py` — 5 regression tests. **3 fail without the change:**

```
$ python -m pytest tests/test_interpreter_main_guard.py -q     # before
FAILED test_dunder_name_is_main
FAILED test_main_guard_body_runs
FAILED test_exception_still_reported
3 failed, 2 passed

$ python -m pytest tests/test_interpreter_main_guard.py -q     # after
5 passed
```

The tests also pin the behaviour that must not regress: unguarded module-level code still
runs, builtins still resolve, and exceptions raised inside a guarded `main()` still surface
as `exc_type`.

`ruff check aide/` and `black --check aide/` both pass.

## Which issues it fixes

Fixes #62.

## Possible follow-up (not in this PR)

A defensive check in `Agent.parse_exec_result` would stop *any* future empty-output path
from poisoning the tree, since a metric can never be trusted when the program printed
nothing:

```python
if not "".join(node._term_out).strip():
    node.is_buggy = True
```

Happy to send that separately if you'd like it.

## Screenshots/videos:

_n/a — terminal output included above._
