### PR TITLE
fix(backend): bound the retry loop and set a request timeout

### DIFF
--- a/aide/backend/backend_openai.py
+++ b/aide/backend/backend_openai.py
@@ -13,6 +13,9 @@ import openai
 logger = logging.getLogger("aide")
 
 OPENAI_BASE_URL = "https://api.openai.com/v1"
+# Per-request timeout (seconds). The SDK default is 600s, which combined with the
+# retry loop in backend.utils makes a stuck request look like a hang.
+OPENAI_REQUEST_TIMEOUT = float(os.getenv("AIDE_OPENAI_TIMEOUT", "180"))
 
 _client: openai.OpenAI = None  # type: ignore
 _custom_client: openai.OpenAI = None  # type: ignore
@@ -30,7 +33,15 @@ def _setup_openai_client():
     global _client
     # Use real OpenAI API with proper API key, explicitly override base_url
     api_key = os.getenv("OPENAI_API_KEY")
-    _client = openai.OpenAI(api_key=api_key, base_url=OPENAI_BASE_URL, max_retries=0)
+    # Cap the per-request wait. Without an explicit timeout the SDK default (600s)
+    # applies, and because backoff_create() retries indefinitely, a single stuck
+    # request stalls the whole run with nothing surfaced to the user.
+    _client = openai.OpenAI(
+        api_key=api_key,
+        base_url=OPENAI_BASE_URL,
+        max_retries=0,
+        timeout=OPENAI_REQUEST_TIMEOUT,
+    )
 
 
 @once
@@ -41,7 +52,10 @@ def _setup_custom_client():
     api_key = os.getenv("OPENAI_API_KEY")
     if base_url:
         _custom_client = openai.OpenAI(
-            api_key=api_key, base_url=base_url, max_retries=0
+            api_key=api_key,
+            base_url=base_url,
+            max_retries=0,
+            timeout=OPENAI_REQUEST_TIMEOUT,
         )
 
 

--- a/aide/backend/utils.py
+++ b/aide/backend/utils.py
@@ -4,6 +4,7 @@ import jsonschema
 from dataclasses_json import DataClassJsonMixin
 import backoff
 import logging
+import os
 from typing import Callable
 
 PromptType = str | dict | list
@@ -13,11 +14,17 @@ OutputType = str | FunctionCallType
 
 logger = logging.getLogger("aide")
 
+# Bound the retry loop. on_predicate with no max_tries retries forever, so a
+# persistent failure (bad key, dead endpoint, model without tool support) hangs
+# the run silently instead of raising.
+BACKOFF_MAX_TRIES = int(os.getenv("AIDE_BACKOFF_MAX_TRIES", "6"))
+
 
 @backoff.on_predicate(
     wait_gen=backoff.expo,
     max_value=60,
     factor=1.5,
+    max_tries=BACKOFF_MAX_TRIES,
 )
 def backoff_create(
     create_fn: Callable, retry_exceptions: list[Exception], *args, **kwargs


### PR DESCRIPTION
## Description

A run can hang indefinitely, with nothing surfaced to the user, because two defaults
compound:

1. **`backoff_create()` retries forever.** `aide/backend/utils.py` decorates with
   `@backoff.on_predicate(wait_gen=backoff.expo, max_value=60, factor=1.5)` — no
   `max_tries`. The wrapped call swallows the exception into `return False`, which is the
   predicate that triggers another retry.
2. **The OpenAI clients set no request timeout.** `openai.OpenAI(api_key=..., base_url=...,
   max_retries=0)` leaves the SDK default of **600s** per request.

So a single stuck request blocks for 10 minutes, raises `APITimeoutError`, gets caught,
logged at `INFO` (invisible at the default `WARNING` level), and retried — forever.

I hit this on a `house_prices` run: it sat at the same node for **23 minutes**. `top`
showed 0% CPU and `ss` showed one ESTABLISHED connection to the API. No error, no log, no
progress. It is indistinguishable from a slow model unless you go process-spelunking.

This is a robustness issue rather than a correctness one, but the failure mode is
particularly unhelpful: an unattended run can burn hours and produce nothing, and
`--steps` gives no upper bound on wall-clock.

## Summary of changes

* `aide/backend/backend_openai.py`
  * add `OPENAI_REQUEST_TIMEOUT` (env `AIDE_OPENAI_TIMEOUT`, default **180s**)
  * pass it to both the default client and the custom-base-url client (the latter is the
    local-server / Ollama path, where a hung request is arguably more likely)
* `aide/backend/utils.py`
  * add `BACKOFF_MAX_TRIES` (env `AIDE_BACKOFF_MAX_TRIES`, default **6**) and pass it to
    `on_predicate`

Both are env-overridable so anyone relying on very long generations can raise them without
patching.

Verified a normal call still works with the timeout in place, including the tool-calling
path used by `review_func_spec`:

```
text: PONG
tool call ok: 0.42 True
```

`ruff check aide/` and `black --check aide/` pass.

### Deliberately not included

I did **not** change what happens after the retries are exhausted. `backoff_create` will
now return `False` to the caller, which will fail with an `AttributeError` on the response
object rather than a clean error. That's still strictly better than hanging forever, but a
tidier fix (raising the last exception) changes behaviour more than I wanted to in a PR
you haven't asked for. Happy to add it if you'd prefer.

## Which issues it fixes

No open issue that I could find; discovered while benchmarking AIDE across 5 tabular tasks.

## Screenshots/videos:

_n/a — terminal output included above._
