### PR TITLE
fix(journal): derive metric direction from the task, not the first node's verdict

### DIFF
--- a/aide/__init__.py
+++ b/aide/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .agent import Agent, determine_metric_direction
+from .agent import Agent, add_task_metric, determine_task_metric
 from .interpreter import Interpreter
 from .journal import Journal
 from omegaconf import OmegaConf
@@ -37,12 +37,14 @@ class Experiment:
         self.cfg = prep_cfg(_cfg)
 
         self.task_desc = load_task_desc(self.cfg)
+        task_metric = determine_task_metric(self.task_desc, self.cfg.agent)
+        self.task_desc = add_task_metric(self.task_desc, task_metric)
 
         with Status("Preparing agent workspace (copying and extracting files) ..."):
             prep_agent_workspace(self.cfg)
 
         self.journal = Journal(
-            metric_maximize=determine_metric_direction(self.task_desc, self.cfg.agent)
+            metric_maximize=task_metric.maximize if task_metric is not None else None
         )
         self.agent = Agent(
             task_desc=self.task_desc,

--- a/aide/__init__.py
+++ b/aide/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .agent import Agent
+from .agent import Agent, determine_metric_direction
 from .interpreter import Interpreter
 from .journal import Journal
 from omegaconf import OmegaConf
@@ -41,7 +41,9 @@ class Experiment:
         with Status("Preparing agent workspace (copying and extracting files) ..."):
             prep_agent_workspace(self.cfg)
 
-        self.journal = Journal()
+        self.journal = Journal(
+            metric_maximize=determine_metric_direction(self.task_desc, self.cfg.agent)
+        )
         self.agent = Agent(
             task_desc=self.task_desc,
             cfg=self.cfg,

--- a/aide/agent.py
+++ b/aide/agent.py
@@ -43,6 +43,62 @@ review_func_spec = FunctionSpec(
     description="Submit a review evaluating the output of the training script.",
 )
 
+metric_direction_func_spec = FunctionSpec(
+    name="submit_metric_direction",
+    json_schema={
+        "type": "object",
+        "properties": {
+            "lower_is_better": {
+                "type": "boolean",
+                "description": "true if the validation metric for this task should be minimized (i.e. a lower metric value is better, such as with MSE), false if it should be maximized (i.e. a higher metric value is better, such as with accuracy).",
+            },
+        },
+        "required": ["lower_is_better"],
+    },
+    description="Report whether the task's validation metric should be minimized or maximized.",
+)
+
+
+def determine_metric_direction(task_desc, acfg) -> bool | None:
+    """Determine the task-level optimization direction of the validation metric.
+
+    Uses the `agent.metric_maximize` config override if set, otherwise queries
+    the feedback model once with the task description. Returns True if the
+    metric should be maximized, False if it should be minimized, or None if the
+    direction could not be determined (the journal then falls back to the
+    direction reported for the first node).
+    """
+    if acfg.metric_maximize is not None:
+        return acfg.metric_maximize
+
+    prompt = {
+        "Introduction": (
+            "You are assessing a machine learning task. "
+            "Based on the task description below, determine whether the validation metric "
+            "for this task should be minimized or maximized."
+        ),
+        "Task description": task_desc,
+    }
+    try:
+        response = cast(
+            dict,
+            query(
+                system_message=prompt,
+                user_message=None,
+                func_spec=metric_direction_func_spec,
+                model=acfg.feedback.model,
+                temperature=acfg.feedback.temp,
+            ),
+        )
+        return not response["lower_is_better"]
+    except Exception:
+        logger.warning(
+            "Failed to infer the metric direction from the task description; "
+            "falling back to the direction reported for the first node",
+            exc_info=True,
+        )
+        return None
+
 
 class Agent:
     def __init__(

--- a/aide/agent.py
+++ b/aide/agent.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from dataclasses import dataclass
 from typing import Any, Callable, cast
 
 import humanize
@@ -43,39 +44,49 @@ review_func_spec = FunctionSpec(
     description="Submit a review evaluating the output of the training script.",
 )
 
-metric_direction_func_spec = FunctionSpec(
-    name="submit_metric_direction",
+task_metric_func_spec = FunctionSpec(
+    name="submit_task_metric",
     json_schema={
         "type": "object",
         "properties": {
+            "metric_name": {
+                "type": "string",
+                "description": "the validation metric every solution should use; reproduce the task's exact metric when one is specified, otherwise choose one such as RMSE, log loss, or accuracy",
+            },
             "lower_is_better": {
                 "type": "boolean",
                 "description": "true if the validation metric for this task should be minimized (i.e. a lower metric value is better, such as with MSE), false if it should be maximized (i.e. a higher metric value is better, such as with accuracy).",
             },
         },
-        "required": ["lower_is_better"],
+        "required": ["metric_name", "lower_is_better"],
     },
-    description="Report whether the task's validation metric should be minimized or maximized.",
+    description="Choose the task's validation metric and report whether it should be minimized or maximized.",
 )
 
 
-def determine_metric_direction(task_desc, acfg) -> bool | None:
-    """Determine the task-level optimization direction of the validation metric.
+@dataclass(frozen=True)
+class TaskMetric:
+    name: str | None
+    maximize: bool
+
+
+def determine_task_metric(task_desc, acfg) -> TaskMetric | None:
+    """Choose one task-level metric and its optimization direction.
 
     Uses the `agent.metric_maximize` config override if set, otherwise queries
-    the feedback model once with the task description. Returns True if the
-    metric should be maximized, False if it should be minimized, or None if the
-    direction could not be determined (the journal then falls back to the
-    direction reported for the first node).
+    the feedback model once with the task description. When the model chooses
+    the metric, callers must add that metric to the task description so code
+    generation and direction resolution refer to the same objective.
     """
     if acfg.metric_maximize is not None:
-        return acfg.metric_maximize
+        return TaskMetric(name=None, maximize=acfg.metric_maximize)
 
     prompt = {
         "Introduction": (
             "You are assessing a machine learning task. "
-            "Based on the task description below, determine whether the validation metric "
-            "for this task should be minimized or maximized."
+            "Use the exact validation metric from the task when one is specified. "
+            "Otherwise, choose one validation metric that every solution must use. "
+            "Determine whether that metric should be minimized or maximized."
         ),
         "Task description": task_desc,
     }
@@ -85,12 +96,18 @@ def determine_metric_direction(task_desc, acfg) -> bool | None:
             query(
                 system_message=prompt,
                 user_message=None,
-                func_spec=metric_direction_func_spec,
+                func_spec=task_metric_func_spec,
                 model=acfg.feedback.model,
                 temperature=acfg.feedback.temp,
             ),
         )
-        return not response["lower_is_better"]
+        metric_name = response["metric_name"]
+        lower_is_better = response["lower_is_better"]
+        if not isinstance(metric_name, str) or not metric_name.strip():
+            raise ValueError("metric direction response omitted a metric name")
+        if not isinstance(lower_is_better, bool):
+            raise ValueError("metric direction response was not boolean")
+        return TaskMetric(name=metric_name.strip(), maximize=not lower_is_better)
     except Exception:
         logger.warning(
             "Failed to infer the metric direction from the task description; "
@@ -98,6 +115,33 @@ def determine_metric_direction(task_desc, acfg) -> bool | None:
             exc_info=True,
         )
         return None
+
+
+def add_task_metric(task_desc, task_metric: TaskMetric | None):
+    """Require the inferred metric in every subsequent solution."""
+    if task_metric is None:
+        return task_desc
+
+    direction = "maximize" if task_metric.maximize else "minimize"
+    if task_metric.name is None:
+        requirement = (
+            "Use one consistent validation metric for every solution and "
+            f"{direction} it."
+        )
+    else:
+        requirement = (
+            f"Use {task_metric.name} as the validation metric for every solution "
+            f"and {direction} it."
+        )
+    if isinstance(task_desc, dict):
+        task_desc = dict(task_desc)
+        existing = task_desc.get("Task evaluation")
+        task_desc["Task evaluation"] = (
+            f"{existing}\n\n{requirement}" if existing else requirement
+        )
+        return task_desc
+
+    return f"{task_desc.rstrip()}\n\n# Task evaluation\n{requirement}"
 
 
 class Agent:

--- a/aide/backend/backend_anthropic.py
+++ b/aide/backend/backend_anthropic.py
@@ -53,7 +53,7 @@ def query(
         filtered_kwargs["model"] = model_name
         logger.debug(f"Using aliased model name: {model_name}")
 
-    if func_spec is not None and func_spec.name == "submit_review":
+    if func_spec is not None:
         filtered_kwargs["tools"] = [func_spec.as_anthropic_tool_dict]
         # Force tool use
         filtered_kwargs["tool_choice"] = func_spec.anthropic_tool_choice_dict

--- a/aide/backend/utils.py
+++ b/aide/backend/utils.py
@@ -1,32 +1,35 @@
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
+import backoff
 import jsonschema
 from dataclasses_json import DataClassJsonMixin
-import backoff
-import logging
-from typing import Callable
 
 PromptType = str | dict | list
 FunctionCallType = dict
 OutputType = str | FunctionCallType
 
 
-logger = logging.getLogger("aide")
+BACKOFF_MAX_TRIES = 5
 
 
-@backoff.on_predicate(
-    wait_gen=backoff.expo,
-    max_value=60,
-    factor=1.5,
-)
 def backoff_create(
-    create_fn: Callable, retry_exceptions: list[Exception], *args, **kwargs
+    create_fn: Callable,
+    retry_exceptions: Sequence[type[Exception]],
+    *args,
+    **kwargs,
 ):
-    try:
+    @backoff.on_exception(
+        wait_gen=backoff.expo,
+        exception=tuple(retry_exceptions),
+        max_value=60,
+        factor=1.5,
+        max_tries=BACKOFF_MAX_TRIES,
+    )
+    def create():
         return create_fn(*args, **kwargs)
-    except retry_exceptions as e:
-        logger.info(f"Backoff exception: {e}")
-        return False
+
+    return create()
 
 
 def opt_messages_to_list(

--- a/aide/journal.py
+++ b/aide/journal.py
@@ -173,7 +173,9 @@ class Journal(DataClassJsonMixin):
             return
 
         for metric in metrics:
-            if metric.maximize != self.metric_maximize:
+            if metric.maximize is None:
+                metric.maximize = self.metric_maximize
+            elif metric.maximize != self.metric_maximize:
                 logger.warning(
                     "Metric direction changed from %s to %s; using the journal direction",
                     metric.maximize,

--- a/aide/journal.py
+++ b/aide/journal.py
@@ -143,7 +143,7 @@ class Journal(DataClassJsonMixin):
     # eda: InteractiveSession = field(default_factory=lambda: InteractiveSession())
 
     def __post_init__(self) -> None:
-        self._canonicalize_metric_directions()
+        self._reconcile_metric_directions()
 
     def __getitem__(self, idx: int) -> Node:
         return self.nodes[idx]
@@ -156,9 +156,10 @@ class Journal(DataClassJsonMixin):
         """Append a new node to the journal."""
         node.step = len(self.nodes)
         self.nodes.append(node)
-        self._canonicalize_metric_directions()
+        self._reconcile_metric_directions()
+        self._warn_on_direction_conflict(node.metric)
 
-    def _canonicalize_metric_directions(self) -> None:
+    def _reconcile_metric_directions(self) -> None:
         metrics = [
             node.metric
             for node in self.nodes
@@ -172,16 +173,26 @@ class Journal(DataClassJsonMixin):
         if self.metric_maximize is None:
             return
 
-        for metric in metrics:
-            if metric.maximize is None:
-                metric.maximize = self.metric_maximize
-            elif metric.maximize != self.metric_maximize:
-                logger.warning(
-                    "Metric direction changed from %s to %s; using the journal direction",
-                    metric.maximize,
-                    self.metric_maximize,
-                )
-                metric.maximize = self.metric_maximize
+    def _warn_on_direction_conflict(self, metric: MetricValue | None) -> None:
+        if (
+            metric is not None
+            and not metric.is_worst
+            and self.metric_maximize is not None
+            and metric.maximize is not None
+            and metric.maximize != self.metric_maximize
+        ):
+            logger.warning(
+                "Metric direction %s disagrees with journal direction %s",
+                metric.maximize,
+                self.metric_maximize,
+            )
+
+    def _metric_rank(self, metric: MetricValue | None) -> tuple[bool, float]:
+        if metric is None or metric.is_worst:
+            return False, 0.0
+        assert metric.value is not None
+        value = float(metric.value)
+        return True, value if self.metric_maximize else -value
 
     @property
     def draft_nodes(self) -> list[Node]:
@@ -204,14 +215,16 @@ class Journal(DataClassJsonMixin):
 
     def get_best_node(self, only_good=True) -> None | Node:
         """Return the best solution found so far (node with the highest validation metric)."""
-        self._canonicalize_metric_directions()
+        self._reconcile_metric_directions()
         if only_good:
             nodes = self.good_nodes
             if not nodes:
                 return None
         else:
             nodes = self.nodes
-        return max(nodes, key=lambda n: n.metric)
+        if self.metric_maximize is None:
+            return max(nodes, key=lambda n: n.metric)
+        return max(nodes, key=lambda n: self._metric_rank(n.metric))
 
     def generate_summary(self, include_code: bool = False) -> str:
         """Generate a summary of the journal for the agent."""

--- a/aide/run.py
+++ b/aide/run.py
@@ -4,7 +4,7 @@ import shutil
 
 from . import backend
 
-from .agent import Agent
+from .agent import Agent, determine_metric_direction
 from .interpreter import Interpreter
 from .journal import Journal, Node
 from .journal2report import journal2report
@@ -69,7 +69,7 @@ def run():
 
     atexit.register(cleanup)
 
-    journal = Journal()
+    journal = Journal(metric_maximize=determine_metric_direction(task_desc, cfg.agent))
     agent = Agent(
         task_desc=task_desc,
         cfg=cfg,

--- a/aide/run.py
+++ b/aide/run.py
@@ -4,7 +4,7 @@ import shutil
 
 from . import backend
 
-from .agent import Agent, determine_metric_direction
+from .agent import Agent, add_task_metric, determine_task_metric
 from .interpreter import Interpreter
 from .journal import Journal, Node
 from .journal2report import journal2report
@@ -58,6 +58,8 @@ def run():
     logger.info(f'Starting run "{cfg.exp_name}"')
 
     task_desc = load_task_desc(cfg)
+    task_metric = determine_task_metric(task_desc, cfg.agent)
+    task_desc = add_task_metric(task_desc, task_metric)
     task_desc_str = backend.compile_prompt_to_md(task_desc)
 
     with Status("Preparing agent workspace (copying and extracting files) ..."):
@@ -69,7 +71,9 @@ def run():
 
     atexit.register(cleanup)
 
-    journal = Journal(metric_maximize=determine_metric_direction(task_desc, cfg.agent))
+    journal = Journal(
+        metric_maximize=task_metric.maximize if task_metric is not None else None
+    )
     agent = Agent(
         task_desc=task_desc,
         cfg=cfg,

--- a/aide/utils/config.py
+++ b/aide/utils/config.py
@@ -45,12 +45,11 @@ class AgentConfig:
     k_fold_validation: int
     expose_prediction: bool
     data_preview: bool
-    metric_maximize: bool | None
-
     code: StageConfig
     feedback: StageConfig
 
     search: SearchConfig
+    metric_maximize: bool | None = None
 
 
 @dataclass

--- a/aide/utils/config.py
+++ b/aide/utils/config.py
@@ -45,6 +45,7 @@ class AgentConfig:
     k_fold_validation: int
     expose_prediction: bool
     data_preview: bool
+    metric_maximize: bool | None
 
     code: StageConfig
     feedback: StageConfig

--- a/aide/utils/config.yaml
+++ b/aide/utils/config.yaml
@@ -40,6 +40,10 @@ agent:
   expose_prediction: False
   # whether to provide the agent with a preview of the data
   data_preview: True
+  # optimization direction of the validation metric: true if higher is better,
+  # false if lower is better; leave null to infer it from the task description
+  # with a single LLM call at the start of the run
+  metric_maximize: null
 
   # LLM settings for coding
   code:

--- a/aide/utils/metric.py
+++ b/aide/utils/metric.py
@@ -16,17 +16,11 @@ class MetricValue(DataClassJsonMixin):
 
     value: float | int | np.number | np.floating | np.ndarray | None
     maximize: bool | None = field(default=None, kw_only=True)
-    # the direction as originally reported (e.g. by the feedback LLM) before
-    # journal-level canonicalization; kept so that inconsistent per-node
-    # verdicts remain diagnosable from journal.json
-    reported_maximize: bool | None = field(default=None, kw_only=True)
 
     def __post_init__(self):
         if self.value is not None:
             assert isinstance(self.value, (float, int, np.number, np.floating))
             self.value = float(self.value)
-        if self.reported_maximize is None:
-            self.reported_maximize = self.maximize
 
     def __gt__(self, other) -> bool:
         """True if self is a _better_ (not necessarily larger) metric value than other"""

--- a/aide/utils/metric.py
+++ b/aide/utils/metric.py
@@ -16,11 +16,17 @@ class MetricValue(DataClassJsonMixin):
 
     value: float | int | np.number | np.floating | np.ndarray | None
     maximize: bool | None = field(default=None, kw_only=True)
+    # the direction as originally reported (e.g. by the feedback LLM) before
+    # journal-level canonicalization; kept so that inconsistent per-node
+    # verdicts remain diagnosable from journal.json
+    reported_maximize: bool | None = field(default=None, kw_only=True)
 
     def __post_init__(self):
         if self.value is not None:
             assert isinstance(self.value, (float, int, np.number, np.floating))
             self.value = float(self.value)
+        if self.reported_maximize is None:
+            self.reported_maximize = self.maximize
 
     def __gt__(self, other) -> bool:
         """True if self is a _better_ (not necessarily larger) metric value than other"""

--- a/tests/test_backend_anthropic.py
+++ b/tests/test_backend_anthropic.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from aide.backend import backend_anthropic
+from aide.backend.utils import FunctionSpec
+
+
+def test_anthropic_supports_arbitrary_function_specs(monkeypatch):
+    captured = {}
+    func_spec = FunctionSpec(
+        name="submit_task_metric",
+        json_schema={
+            "type": "object",
+            "properties": {"lower_is_better": {"type": "boolean"}},
+            "required": ["lower_is_better"],
+        },
+        description="Submit a task metric.",
+    )
+    tool_block = SimpleNamespace(
+        type="tool_use",
+        name=func_spec.name,
+        input={"lower_is_better": True},
+    )
+    message = SimpleNamespace(
+        content=[tool_block],
+        usage=SimpleNamespace(input_tokens=2, output_tokens=1),
+        stop_reason="tool_use",
+        model="claude-test",
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return message
+
+    monkeypatch.setattr(backend_anthropic, "_setup_anthropic_client", lambda: None)
+    monkeypatch.setattr(
+        backend_anthropic,
+        "_client",
+        SimpleNamespace(messages=SimpleNamespace(create=create)),
+    )
+
+    output, _, _, _, _ = backend_anthropic.query(
+        system_message="Choose a metric.",
+        user_message=None,
+        func_spec=func_spec,
+        model="claude-test",
+    )
+
+    assert output == {"lower_is_better": True}
+    assert captured["tools"] == [func_spec.as_anthropic_tool_dict]
+    assert captured["tool_choice"] == func_spec.anthropic_tool_choice_dict

--- a/tests/test_backend_utils.py
+++ b/tests/test_backend_utils.py
@@ -1,0 +1,59 @@
+import pytest
+
+from aide.backend import utils
+
+
+class RetryableError(Exception):
+    pass
+
+
+def _no_wait(**_kwargs):
+    while True:
+        yield 0
+
+
+def test_backoff_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(utils, "BACKOFF_MAX_TRIES", 2)
+    monkeypatch.setattr(utils.backoff, "expo", _no_wait)
+    attempts = 0
+
+    def create():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RetryableError
+        return "ok"
+
+    assert utils.backoff_create(create, [RetryableError]) == "ok"
+    assert attempts == 2
+
+
+def test_backoff_reraises_retryable_exception_after_limit(monkeypatch):
+    monkeypatch.setattr(utils, "BACKOFF_MAX_TRIES", 2)
+    monkeypatch.setattr(utils.backoff, "expo", _no_wait)
+    attempts = 0
+
+    def create():
+        nonlocal attempts
+        attempts += 1
+        raise RetryableError("still unavailable")
+
+    with pytest.raises(RetryableError, match="still unavailable"):
+        utils.backoff_create(create, [RetryableError])
+
+    assert attempts == 2
+
+
+def test_backoff_does_not_retry_unlisted_exception(monkeypatch):
+    monkeypatch.setattr(utils, "BACKOFF_MAX_TRIES", 2)
+    attempts = 0
+
+    def create():
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("invalid request")
+
+    with pytest.raises(ValueError, match="invalid request"):
+        utils.backoff_create(create, [RetryableError])
+
+    assert attempts == 1

--- a/tests/test_metric_comparison.py
+++ b/tests/test_metric_comparison.py
@@ -96,7 +96,7 @@ def _node(value, maximize):
     )
 
 
-def test_journal_canonicalizes_conflicting_direction(caplog):
+def test_journal_reconciles_conflicting_direction(caplog):
     journal = Journal()
     first = _node(0.9, maximize=True)
     conflicting = _node(0.85, maximize=False)
@@ -105,9 +105,13 @@ def test_journal_canonicalizes_conflicting_direction(caplog):
     journal.append(conflicting)
 
     assert journal.metric_maximize is True
-    assert conflicting.metric.maximize is True
+    assert conflicting.metric.maximize is False
     assert journal.get_best_node() is first
-    assert "using the journal direction" in caplog.text
+    assert "disagrees with journal direction" in caplog.text
+
+    caplog.clear()
+    journal.get_best_node()
+    assert "disagrees with journal direction" not in caplog.text
 
 
 def test_best_node_is_permutation_invariant():

--- a/tests/test_metric_direction.py
+++ b/tests/test_metric_direction.py
@@ -12,9 +12,10 @@ import logging
 from omegaconf import OmegaConf
 
 import aide.agent as agent_module
-from aide.agent import determine_metric_direction
+from aide.agent import TaskMetric, add_task_metric, determine_task_metric
 from aide.journal import Journal, Node
 from aide.utils import serialize
+from aide.utils.config import AgentConfig
 from aide.utils.metric import MetricValue
 
 
@@ -36,38 +37,49 @@ def _acfg(metric_maximize=None):
 
 
 def test_task_level_direction_wins_over_conflicting_first_node_verdict():
-    # task says lower is better; the first node's verdict says the opposite
     journal = Journal(metric_maximize=False)
     journal.append(_node(0.9, maximize=True))
     journal.append(_node(0.2, maximize=False))
 
     assert journal.metric_maximize is False
-    assert journal.nodes[0].metric.maximize is False
+    assert [node.metric.maximize for node in journal.nodes] == [True, False]
     assert journal.get_best_node().metric.value == 0.2
 
 
-def test_none_direction_is_canonicalized_without_warning(caplog):
+def test_none_direction_is_ranked_without_warning(caplog):
     journal = Journal(metric_maximize=True)
     with caplog.at_level(logging.WARNING, logger="aide"):
         journal.append(_node(0.5, maximize=None))
 
-    assert "Metric direction changed" not in caplog.text
-    # still canonicalized so comparisons cannot fail on a None direction
-    assert journal.nodes[0].metric.maximize is True
+    assert "disagrees with journal direction" not in caplog.text
+    assert journal.nodes[0].metric.maximize is None
+    assert journal.get_best_node() is journal.nodes[0]
 
 
 def test_reported_direction_persisted_in_journal_json(tmp_path):
     journal = Journal(metric_maximize=True)
     journal.append(_node(0.9, maximize=True))
-    journal.append(_node(0.85, maximize=False))  # conflicting per-node verdict
+    journal.append(_node(0.85, maximize=False))
 
     path = tmp_path / "journal.json"
     serialize.dump_json(journal, path)
     data = json.loads(path.read_text())
 
-    metrics = [n["metric"] for n in data["nodes"]]
-    assert [m["maximize"] for m in metrics] == [True, True]
-    assert [m["reported_maximize"] for m in metrics] == [True, False]
+    assert data["metric_maximize"] is True
+    metrics = [node["metric"] for node in data["nodes"]]
+    assert [metric["maximize"] for metric in metrics] == [True, False]
+    assert all("reported_maximize" not in metric for metric in metrics)
+
+
+def test_none_direction_survives_journal_round_trip():
+    journal = Journal(metric_maximize=True)
+    journal.append(_node(0.5, maximize=None))
+
+    loaded = serialize.loads_json(serialize.dumps_json(journal), Journal)
+
+    assert loaded.metric_maximize is True
+    assert loaded.nodes[0].metric.maximize is None
+    assert loaded.get_best_node() is loaded.nodes[0]
 
 
 def test_config_override_skips_llm_call(monkeypatch):
@@ -76,26 +88,57 @@ def test_config_override_skips_llm_call(monkeypatch):
 
     monkeypatch.setattr(agent_module, "query", fail_query)
 
-    assert (
-        determine_metric_direction("some task", _acfg(metric_maximize=False)) is False
-    )
-    assert determine_metric_direction("some task", _acfg(metric_maximize=True)) is True
+    minimize = determine_task_metric("some task", _acfg(False))
+    maximize = determine_task_metric("some task", _acfg(True))
+
+    assert minimize == TaskMetric(None, False)
+    assert maximize == TaskMetric(None, True)
+    assert "minimize" in add_task_metric("some task", minimize)
+    assert "maximize" in add_task_metric("some task", maximize)
 
 
-def test_direction_inferred_from_task_description(monkeypatch):
+def test_metric_and_direction_inferred_from_task_description(monkeypatch):
     captured = {}
 
     def fake_query(**kwargs):
         captured.update(kwargs)
-        return {"lower_is_better": True}
+        return {"metric_name": "RMSE", "lower_is_better": True}
 
     monkeypatch.setattr(agent_module, "query", fake_query)
 
-    direction = determine_metric_direction(
-        "Predict house prices; report RMSE.", _acfg()
-    )
-    assert direction is False
-    assert captured["func_spec"].name == "submit_metric_direction"
+    task_metric = determine_task_metric("Predict house prices; report RMSE.", _acfg())
+
+    assert task_metric == TaskMetric("RMSE", False)
+    assert captured["func_spec"].name == "submit_task_metric"
+    augmented = add_task_metric({"Task": "Predict house prices."}, task_metric)
+    assert "RMSE" in augmented["Task evaluation"]
+    assert "minimize" in augmented["Task evaluation"]
+
+
+def test_inferred_metric_is_used_by_later_solutions(monkeypatch):
+    def fake_query(**kwargs):
+        return {"metric_name": "log loss", "lower_is_better": True}
+
+    monkeypatch.setattr(agent_module, "query", fake_query)
+
+    task_metric = determine_task_metric("Solve a classification task.", _acfg())
+    task_desc = add_task_metric("Solve a classification task.", task_metric)
+    journal = Journal(metric_maximize=task_metric.maximize)
+    journal.append(_node(0.5, maximize=False))
+    journal.append(_node(0.2, maximize=False))
+
+    assert "log loss" in task_desc
+    assert "minimize" in task_desc
+    assert journal.get_best_node().metric.value == 0.2
+
+
+def test_old_agent_config_defaults_metric_override_to_none():
+    old_config = OmegaConf.load("aide/utils/config.yaml").agent
+    del old_config.metric_maximize
+
+    merged = OmegaConf.merge(OmegaConf.structured(AgentConfig), old_config)
+
+    assert merged.metric_maximize is None
 
 
 def test_inference_failure_falls_back_to_none(monkeypatch):
@@ -104,4 +147,4 @@ def test_inference_failure_falls_back_to_none(monkeypatch):
 
     monkeypatch.setattr(agent_module, "query", fake_query)
 
-    assert determine_metric_direction("some task", _acfg()) is None
+    assert determine_task_metric("some task", _acfg()) is None

--- a/tests/test_metric_direction.py
+++ b/tests/test_metric_direction.py
@@ -1,0 +1,107 @@
+"""Tests for task-level metric direction handling.
+
+Follow-up to #91 / #92: the journal direction should come from the task
+(config override or task-description inference) rather than be latched from
+the first node's per-node verdict, and the originally-reported per-node
+directions should be preserved in journal.json.
+"""
+
+import json
+import logging
+
+from omegaconf import OmegaConf
+
+import aide.agent as agent_module
+from aide.agent import determine_metric_direction
+from aide.journal import Journal, Node
+from aide.utils import serialize
+from aide.utils.metric import MetricValue
+
+
+def _node(value, maximize):
+    return Node(
+        code="",
+        metric=MetricValue(value, maximize=maximize),
+        is_buggy=False,
+    )
+
+
+def _acfg(metric_maximize=None):
+    return OmegaConf.create(
+        {
+            "metric_maximize": metric_maximize,
+            "feedback": {"model": "test-model", "temp": 0.5},
+        }
+    )
+
+
+def test_task_level_direction_wins_over_conflicting_first_node_verdict():
+    # task says lower is better; the first node's verdict says the opposite
+    journal = Journal(metric_maximize=False)
+    journal.append(_node(0.9, maximize=True))
+    journal.append(_node(0.2, maximize=False))
+
+    assert journal.metric_maximize is False
+    assert journal.nodes[0].metric.maximize is False
+    assert journal.get_best_node().metric.value == 0.2
+
+
+def test_none_direction_is_canonicalized_without_warning(caplog):
+    journal = Journal(metric_maximize=True)
+    with caplog.at_level(logging.WARNING, logger="aide"):
+        journal.append(_node(0.5, maximize=None))
+
+    assert "Metric direction changed" not in caplog.text
+    # still canonicalized so comparisons cannot fail on a None direction
+    assert journal.nodes[0].metric.maximize is True
+
+
+def test_reported_direction_persisted_in_journal_json(tmp_path):
+    journal = Journal(metric_maximize=True)
+    journal.append(_node(0.9, maximize=True))
+    journal.append(_node(0.85, maximize=False))  # conflicting per-node verdict
+
+    path = tmp_path / "journal.json"
+    serialize.dump_json(journal, path)
+    data = json.loads(path.read_text())
+
+    metrics = [n["metric"] for n in data["nodes"]]
+    assert [m["maximize"] for m in metrics] == [True, True]
+    assert [m["reported_maximize"] for m in metrics] == [True, False]
+
+
+def test_config_override_skips_llm_call(monkeypatch):
+    def fail_query(*args, **kwargs):
+        raise AssertionError("query must not be called when the override is set")
+
+    monkeypatch.setattr(agent_module, "query", fail_query)
+
+    assert (
+        determine_metric_direction("some task", _acfg(metric_maximize=False)) is False
+    )
+    assert determine_metric_direction("some task", _acfg(metric_maximize=True)) is True
+
+
+def test_direction_inferred_from_task_description(monkeypatch):
+    captured = {}
+
+    def fake_query(**kwargs):
+        captured.update(kwargs)
+        return {"lower_is_better": True}
+
+    monkeypatch.setattr(agent_module, "query", fake_query)
+
+    direction = determine_metric_direction(
+        "Predict house prices; report RMSE.", _acfg()
+    )
+    assert direction is False
+    assert captured["func_spec"].name == "submit_metric_direction"
+
+
+def test_inference_failure_falls_back_to_none(monkeypatch):
+    def fake_query(**kwargs):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(agent_module, "query", fake_query)
+
+    assert determine_metric_direction("some task", _acfg()) is None


### PR DESCRIPTION
Fixes #92. Follow-up to #91.

## Problem

The journal-level `metric_maximize` was latched from the first node that carried a usable metric — i.e. from a single per-node `lower_is_better` verdict by the feedback LLM, the exact judgment #57 reports as flaky. One wrong early verdict meant every later (correct) verdict got coerced to the wrong direction, `get_best_node()` returned the worst solution, and greedy search expanded from the worst node for the rest of the run, with only WARNING log lines as a trace. #91 made comparisons crash-free and order-independent given a canonical direction, but the canonical direction itself was still a first-writer-wins guess.

## Design

The optimization direction is a property of the task, so it is now resolved once at run start and passed to `Journal(metric_maximize=...)` (which already accepted it but was never given it by either entry point):

1. **Config override**: new optional `agent.metric_maximize` setting (`true` = higher is better, `false` = lower is better). If the user knows the direction, no LLM is involved.
2. **Task-level inference**: otherwise `determine_metric_direction()` makes a single function-call query to the feedback model with the full task description. This is a strictly better witness than the first node's verdict: it sees the task statement (which usually names the metric) rather than one training log, and it happens once instead of being implicitly re-decided per node.
3. **Fallback**: if inference fails (e.g. backend error), it returns `None` and the journal falls back to the previous behavior (adopt the first node's direction). Verified manually that a missing API key degrades gracefully to the fallback instead of crashing the run.

Per-node verdicts are still recorded: `MetricValue` keeps `reported_maximize` — the direction as originally reported before canonicalization — which lands in `journal.json`, so runs where the feedback model flip-flops on `lower_is_better` remain diagnosable after the fact.

Also: metrics with `maximize=None` are now canonicalized silently instead of tripping the "direction changed" warning (they never reported a direction to change).

Both entry points are covered: `aide/run.py` (CLI) and `Experiment.__init__` (API, which the webui uses).

## Validation

```
$ .venv/bin/python -m pytest tests/ -q
29 passed
```

6 new tests in `tests/test_metric_direction.py`:
- task-level direction wins over a conflicting first-node verdict
- `maximize=None` does not trigger the direction-changed warning (but is still canonicalized)
- originally-reported per-node direction persisted in `journal.json`
- config override short-circuits the LLM call
- inference maps `lower_is_better` to `maximize` correctly (mocked query)
- inference failure falls back to `None`

Ruff 0.7.1 and Black 24.3.0 (the CI-pinned versions) pass on `aide/`.
